### PR TITLE
Fix missing content by running JS init immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,6 @@
   </button>
 
   <!-- Load JavaScript - Uses built-in fallback in script.js when data.json is unavailable -->
-  <script src="script.js"></script>
+  <script defer src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -693,8 +693,7 @@ function initScrollAnimations() {
   });
 }
 
-// Initialize on page load
-document.addEventListener('DOMContentLoaded', () => {
+function initSite() {
   document.body.classList.add('js-enabled');
   initThemeToggle();
   initializeNavbar();
@@ -702,21 +701,27 @@ document.addEventListener('DOMContentLoaded', () => {
   setupSmoothScrolling();
   addScrollEffects();
   setCurrentYear();
-  
+
   // Initialize enhanced features
   createParticles();
   initCursorTrail();
   initKonamiCode();
   initDataScienceEasterEggs();
   initScrollAnimations();
-  
+
   // Add some flair to the loading
   document.body.style.opacity = '0';
   setTimeout(() => {
     document.body.style.transition = 'opacity 0.5s ease';
     document.body.style.opacity = '1';
   }, 100);
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initSite);
+} else {
+  initSite();
+}
 
 function setCurrentYear() {
   const yearElement = document.getElementById('current-year');


### PR DESCRIPTION
## Summary
- ensure `script.js` runs after DOM is parsed
- handle page init whether or not `DOMContentLoaded` fired

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6854386eef74832b8e135cf960ecec75