### PR TITLE
Remove Tailwind dependency and fix Font Awesome SRI

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Loading...</title>
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-1sCRPdkRXW3UX0DpD+s/COM24kTx5cDIeEJD7BqXc9E+u6KDAdAm8YGtS+wGGyRyvE4s46HoPazTA7kGEXdDzw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
     <header class="hero glass text-center p-8 space-y-2">

--- a/style.css
+++ b/style.css
@@ -94,3 +94,20 @@ footer {
         grid-template-columns: repeat(2, 1fr);
     }
 }
+/* Utility classes replacing Tailwind */
+.text-center { text-align: center; }
+.p-4 { padding: 1rem; }
+.p-8 { padding: 2rem; }
+.mt-6 { margin-top: 1.5rem; }
+.flex { display: flex; }
+.flex-wrap { flex-wrap: wrap; }
+.justify-center { justify-content: center; }
+.items-center { align-items: center; }
+.gap-4 { gap: 1rem; }
+.grid { display: grid; }
+.gap-6 { gap: 1.5rem; }
+.space-y-2 > * + * { margin-top: 0.5rem; }
+.text-xl { font-size: 1.25rem; }
+@media (min-width: 768px) {
+  .md\:grid-cols-2 { grid-template-columns: repeat(2, 1fr); }
+}


### PR DESCRIPTION
## Summary
- replace Tailwind classes with vanilla CSS utilities
- remove Tailwind CDN
- fix the SRI hash for Font Awesome so it loads correctly

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68550c6a9720832bb8ca1e6a95ccc6a2